### PR TITLE
zope.deferredimport 6.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,38 @@
 {% set name = "zope.deferredimport" %}
-{% set version = "4.3.1" %}
+{% set version = "6.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 57b2345e7b5eef47efcd4f634ff16c93e4265de3dcf325afc7315ade48d909e1
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace(".", "_") }}-{{ version }}.tar.gz
+  sha256: dcceab59470497adb1bf32051a12355cde4e7f629ae1d21ac16ba830bc717fed
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python
     - pip
+    - python
+    - setuptools 78.1.1
+    - wheel
   run:
     - python
     - zope.proxy
 
 test:
   imports:
-    - {{ name }}
+    - zope.deferredimport
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -v --pyargs zope.deferredimport.tests
 
 about:
   home: https://github.com/zopefoundation/zope.deferredimport


### PR DESCRIPTION
zope.deferredimport 6.0 

**Destination channel:** Defaults

### Links

- [PKG-10279]
- dev_url:        https://github.com/zopefoundation/zope.deferredimport/tree/6.0
- conda_forge:    https://github.com/conda-forge/zope.deferredimport-feedstock
- pypi:           https://pypi.org/project/zope.deferredimport/6.0
- pypi inspector: https://inspector.pypi.io/project/zope.deferredimport/6.0

### Explanation of changes:

- new version number
- new addition to the registry


[PKG-10279]: https://anaconda.atlassian.net/browse/PKG-10279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ